### PR TITLE
Fixed incorrrect link on Getting Started page.

### DIFF
--- a/docs/pyramid.rst
+++ b/docs/pyramid.rst
@@ -16,7 +16,7 @@ speed right away:
   `single file tasks tutorial </projects/pyramid_tutorials/en/latest/single_file_tasks/single_file_tasks.html>`_ page. 
 
 * Like learning by example? Check out to the `wiki tutorial
-  </projects/pyramid/en/1.2-branch/tutorials/wiki2/index.html>`_.
+  </projects/pyramid/en/latest/tutorials/wiki2/index.html>`_.
 
 * Need help?  See :ref:`support-desc`.
 


### PR DESCRIPTION
The link to the SQLAlchemy + URL Dispatch Wiki Tutorial was pointing to the 1.2 branch of the tutorial.  With this fix, it now points to the latest version, as @mcdonc suggested to do. I ran this by @goodwill as well.
