### PR TITLE
Adding link to firstapp in Getting Start section

### DIFF
--- a/docs/pyramid.rst
+++ b/docs/pyramid.rst
@@ -9,6 +9,9 @@ speed right away:
 
 * Check out  our `FAQ </faq/pyramid.html>`_.
 
+* To see a minimal Pyramid web application and how to run it, checkout
+  `creating your first Pyramid application </projects/pyramid/en/1.3-branch/narr/firstapp.html>`_.
+
 * For help getting Pyramid set up, try the `install guide
   </projects/pyramid/en/1.3-branch/narr/install.html>`_.
 


### PR DESCRIPTION
Instead of duplicating the helloworld application on the install page, link to it in the Getting Started section and provide links to the installation chapter from there.
