### PR TITLE
More separation of latest and master documentation

### DIFF
--- a/docs/pyramid.rst
+++ b/docs/pyramid.rst
@@ -34,8 +34,8 @@ Stable branch : version 1.4.5 (latest)
   <http://media.readthedocs.org/epub/pyramid/latest/pyramid.epub>`_) - narrative and API
   documentation for Pyramid's latest version, 1.4.5, the current stable release.
 
-Development branch : version 1.5 (master)
-++++++++++++++++++++++++++++++++++++++++++++++++
+Development branch : upcoming 1.5 (master)
+++++++++++++++++++++++++++++++++++++++++++
 
 * `Pyramid development documentation </projects/pyramid/en/master/>`_ - narrative and API
   documentation for Pyramid's unreleased in-development version.
@@ -51,18 +51,8 @@ Tutorials and cookbooks
   </projects/pyramid_cookbook/en/latest/>`_ presents
   topical, practical usages of Pyramid.  The cookbook is unfinished.
 
-Branches history
-++++++++++++++++
-
-* `Pyramid documentation 1.5 </projects/pyramid/en/1.5-branch/>`_ (`1.5 PDF
-  <http://media.readthedocs.org/pdf/pyramid/1.5-branch/pyramid.pdf>`_) (`1.5 Epub
-  <http://media.readthedocs.org/epub/pyramid/1.5-branch/pyramid.epub>`_) - narrative and API
-  documentation for Pyramid's 1.5 version, in alpha/beta.
-
-* `Pyramid documentation 1.4 </projects/pyramid/en/1.4-branch/>`_ (`1.4 PDF
-  <http://media.readthedocs.org/pdf/pyramid/1.4-branch/pyramid.pdf>`_) (`1.4 Epub
-  <http://media.readthedocs.org/epub/pyramid/1.4-branch/pyramid.epub>`_) - narrative and API
-  documentation for Pyramid's 1.4 version, the current stable release.
+Previous versions
++++++++++++++++++
 
 * `Pyramid documentation 1.3 </projects/pyramid/en/1.3-branch/>`_ (`1.3 PDF
   <http://media.readthedocs.org/pdf/pyramid/1.3-branch/pyramid.pdf>`_) (`1.3 Epub


### PR DESCRIPTION
Make the main page more explicit about which version is stable (latest) and which one in development (master).
