### PR TITLE
Fix link syntax of RAML and Nefertari references.

### DIFF
--- a/docs/pyramid.rst
+++ b/docs/pyramid.rst
@@ -312,8 +312,8 @@ often have dependencies beyond those of the Pyramid core.
   - Version Control: https://github.com/ptahproject/ptah
 
 `Ramses <https://ramses.readthedocs.org/>`_
-  Ramses is a library that generates a RESTful API using `RAML <http://raml.org>`. 
-  It uses Pyramid and `Nefertari <https://nefertari.readthedocs.org/>` which provides ElasticSearch-powered views.
+  Ramses is a library that generates a RESTful API using `RAML <http://raml.org>`_.
+  It uses Pyramid and `Nefertari <https://nefertari.readthedocs.org/>`_ which provides ElasticSearch-powered views.
 
   - Version Control: https://github.com/brandicted/ramses
 


### PR DESCRIPTION
The links for RAML and Nefertari didn't use the correct RST syntax as the underscores at the end were missing. Therefore they didn't translate into proper links when being compiled.