### PR TITLE
Ringo moved to Github

### DIFF
--- a/docs/pyramid.rst
+++ b/docs/pyramid.rst
@@ -374,7 +374,7 @@ dependencies beyond those of the Pyramid core.
 
 `Ringo <http://www.ringo-framework.org>`_
   Ringo is an extensible high-level web application framework with strength in
-  building form based management or administration software, providing read to
+  building form based management or administration software, providing ready to
   use components often needed in web applications.
 
   - Version Control: https://bitbucket.org/ti/ringo

--- a/docs/pyramid.rst
+++ b/docs/pyramid.rst
@@ -377,7 +377,7 @@ dependencies beyond those of the Pyramid core.
   building form based management or administration software, providing ready to
   use components often needed in web applications.
 
-  - Version Control: https://bitbucket.org/ti/ringo
+  - Version Control: https://github.com/ringo-framework/ringo
 
 `Substance-D <http://substanced.net/>`_
   An application server built upon the Pyramid web framework. It provides a


### PR DESCRIPTION
As  Ringo moved from Bitbucket to Github the links needed to be adapted