### PR TITLE
release version 1.7

### DIFF
--- a/docs/pyramid.rst
+++ b/docs/pyramid.rst
@@ -20,42 +20,41 @@ speed right away:
   :ref:`Quick Tutorial for Pyramid <pyramid:quick_tutorial>`.
 
 * Like learning by example? Check out to the official :ref:`Pyramid Tutorials
-  <pyramid:html_tutorials>` as well as the community-contributed :ref:`Pyramid
+  <pyramid:tutorials>` as well as the community-contributed :ref:`Pyramid
   Tutorials <tutorials:pyramid-tutorials>` and :ref:`Pyramid Cookbook Recipes
   <cookbook:pyramid-cookbook>`.
 
-* Need help?  See :ref:`support-desc`.
+* For help, see :ref:`Support and Development
+  <pyramid:support-and-development>`.
 
 Main Documentation
 ------------------
 
-Stable branch : version 1.6 (latest)
+Stable branch : version 1.7 (latest)
 ++++++++++++++++++++++++++++++++++++
 
-* `Pyramid latest documentation </projects/pyramid/en/1.6-branch/>`_
-  (`latest PDF
+* :ref:`Pyramid latest documentation <pyramid:index>` (`latest PDF
   <http://media.readthedocs.org/pdf/pyramid/latest/pyramid.pdf>`_)
-  (`latest Epub <http://media.readthedocs.org/epub/pyramid/latest/pyramid
-  .epub>`_)
-  - narrative and API documentation for Pyramid's latest version, 1.6, the
+  (`latest Epub <http://media.readthedocs.org/epub/pyramid/latest/pyramid.epub>`_)
+  - narrative and API documentation for Pyramid's latest version, 1.7, the
   current stable release.
 
-Pre-release branch : version 1.7
-++++++++++++++++++++++++++++++++
-
-* `Pyramid documentation 1.7 </projects/pyramid/en/1.7-branch/>`_
-  (`1.7 PDF
-  <http://media.readthedocs.org/pdf/pyramid/1.7-branch/pyramid.pdf>`_)
-  (`latest Epub <http://media.readthedocs.org/epub/pyramid/1.7-branch/pyramid
-  .epub>`_)
-  - narrative and API documentation for Pyramid's pre-release version, 1.7,
-  in dev, alpha, or beta status.
+.. Pre-release branch : version 1.8
+.. ++++++++++++++++++++++++++++++++
+..
+.. * `Pyramid documentation 1.8
+..   <http://docs.pylonsproject.org/projects/pyramid/en/1.8-branch/>`_ (`1.8
+..   PDF <http://media.readthedocs.org/pdf/pyramid/1.8-branch/pyramid.pdf>`_)
+..   (`1.8 Epub <http://media.readthedocs.org/epub/pyramid/1.8-branch/pyramid.epub>`_)
+..   - narrative and API documentation for Pyramid's pre-release version, 1.8,
+..   in dev, alpha, or beta status.
 
 Development branch : upcoming 1.8 (master)
 ++++++++++++++++++++++++++++++++++++++++++
 
-* `Pyramid development documentation </projects/pyramid/en/master/>`_ -
-  narrative and API documentation for Pyramid's in-development version.
+* `Pyramid development documentation
+  <http://docs.pylonsproject.org/projects/pyramid/en/master/>`_ - narrative and
+  API documentation for Pyramid's in-development version.
 
 .. _tutorials-cookbook:
 
@@ -76,332 +75,54 @@ Tutorials and Cookbook Recipes
 
 Previous versions
 +++++++++++++++++
-* `Pyramid documentation 1.5 </projects/pyramid/en/1.5-branch/>`_ (`1.5 PDF
+* `Pyramid documentation 1.6
+  <http://docs.pylonsproject.org/projects/pyramid/en/1.6-branch/>`_ (`1.6 PDF
+  <http://media.readthedocs.org/pdf/pyramid/1.6-branch/pyramid.pdf>`_) (`1.6
+  Epub <http://media.readthedocs.org/epub/pyramid/1.6-branch/pyramid.epub>`_) -
+  narrative and API documentation for Pyramid's 1.6 version.
+
+* `Pyramid documentation 1.5
+  <http://docs.pylonsproject.org/projects/pyramid/en/1.5-branch/>`_ (`1.5 PDF
   <http://media.readthedocs.org/pdf/pyramid/1.5-branch/pyramid.pdf>`_) (`1.5
   Epub <http://media.readthedocs.org/epub/pyramid/1.5-branch/pyramid.epub>`_) -
   narrative and API documentation for Pyramid's 1.5 version.
 
-* `Pyramid documentation 1.4 </projects/pyramid/en/1.4-branch/>`_ (`1.4 PDF
+* `Pyramid documentation 1.4
+  <http://docs.pylonsproject.org/projects/pyramid/en/1.4-branch/>`_ (`1.4 PDF
   <http://media.readthedocs.org/pdf/pyramid/1.4-branch/pyramid.pdf>`_) (`1.4
   Epub <http://media.readthedocs.org/epub/pyramid/1.4-branch/pyramid.epub>`_) -
   narrative and API documentation for Pyramid's 1.4 version.
 
-* `Pyramid documentation 1.3 </projects/pyramid/en/1.3-branch/>`_ (`1.3 PDF
+* `Pyramid documentation 1.3
+  <http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/>`_ (`1.3 PDF
   <http://media.readthedocs.org/pdf/pyramid/1.3-branch/pyramid.pdf>`_) (`1.3
   Epub <http://media.readthedocs.org/epub/pyramid/1.3-branch/pyramid.epub>`_) -
   narrative and API documentation for Pyramid's 1.3 version.
 
-* `Pyramid documentation 1.2 </projects/pyramid/en/1.2-branch/>`_ (`1.2 PDF
+* `Pyramid documentation 1.2
+  <http://docs.pylonsproject.org/projects/pyramid/en/1.2-branch/>`_ (`1.2 PDF
   <http://media.readthedocs.org/pdf/pyramid/1.2-branch/pyramid.pdf>`_) (`1.2
   Epub <http://media.readthedocs.org/epub/pyramid/1.2-branch/pyramid.epub>`_) -
   narrative and API documentation for Pyramid's 1.2 version.
 
-* `Pyramid documentation 1.1 </projects/pyramid/en/1.1-branch/>`_ (`1.1 PDF
+* `Pyramid documentation 1.1
+  <http://docs.pylonsproject.org/projects/pyramid/en/1.1-branch/>`_ (`1.1 PDF
   <http://media.readthedocs.org/pdf/pyramid/1.1-branch/pyramid.pdf>`_) (`1.1
   Epub <http://media.readthedocs.org/epub/pyramid/1.1-branch/pyramid.epub>`_) -
   narrative and API documentation for Pyramid's 1.1 version.
 
-* `Pyramid documentation 1.0 </projects/pyramid/en/1.0-branch/>`_ (`1.0 PDF
+* `Pyramid documentation 1.0
+  <http://docs.pylonsproject.org/projects/pyramid/en/1.0-branch/>`_ (`1.0 PDF
   <http://media.readthedocs.org/pdf/pyramid/1.0-branch/pyramid.pdf>`_) (`1.0
   Epub <http://media.readthedocs.org/epub/pyramid/1.0-branch/pyramid.epub>`_) -
   narrative and API documentation for Pyramid's 1.0 version.
 
+
 .. _pyramid-add-ons:
 
-Pyramid Add-ons
----------------
-
-Supported Add-ons
-+++++++++++++++++
-
-Pyramid supports extensibility through add-ons.  The following add-ons are
-officially endorsed by the Pylons Project. Documentation for each add-on is
-hosted at its respective name under the Pylons Project.
-
-* `pyramid_chameleon </projects/pyramid-chameleon/en/latest/>`_: Chameleon
-  templating bindings for Pyramid.
-
-  - Maintained by: Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_chameleon
-
-* `pyramid_debugtoolbar </projects/pyramid-debugtoolbar/en/latest/>`_, an
-  interactive HTML debug toolbar for Pyramid.
-
-  - Maintained by:  Chris McDonough, Blaise Laflamme
-
-  - Version Control: https://github.com/Pylons/pyramid_debugtoolbar
-
-* `pyramid_exclog </projects/pyramid-exclog/en/latest/>`_, a package which logs
-  exceptions from Pyramid applications.
-
-  - Maintained by:  Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_exclog
-
-* `pyramid_handlers </projects/pyramid-handlers/en/latest/>`_: analogue of
-  Pylons-style "controllers" for Pyramid.
-
-  - Maintained by: Ben Bangert, Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_handlers
-
-* `pyramid_jinja2 </projects/pyramid-jinja2/en/latest/>`_: `Jinja2
-  <http://jinja.pocoo.org/>`_ template renderer for Pyramid
-
-  - Maintained by: Domen Kožar
-
-  - Version Control: https://github.com/Pylons/pyramid_jinja2
-
-* `pyramid_jqm </projects/pyramid-jqm/en/latest/>`_, scaffolding for developing
-  jQuery Mobile apps with Pyramid.
-
-  - Maintained by:  Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_jqm
-
-* `pyramid_layout </projects/pyramid-layout/en/latest/>`_: Pyramid add-on for
-  managing UI layouts.
-
-  - Maintained by: Chris Rossi, Paul Everitt, Blaise Laflamme
-
-  - Version Control: https://github.com/Pylons/pyramid_layout
-
-* `pyramid_ldap </projects/pyramid-ldap/en/latest/>`_, an LDAP authentication
-  policy for Pyramid.
-
-  - Maintained by:  Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_ldap
-
-* `pyramid_mailer </projects/pyramid-mailer/en/latest/>`_: a package for the
-  Pyramid framework to take the pain out of sending emails.
-
-  - Maintained by:  Dan Jacobs, Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_mailer
-
-* `pyramid_mako </projects/pyramid-mako/en/latest/>`_: Mako templating bindings
-  for Pyramid.
-
-  - Maintained by: Bert JW Regeer
-
-  - Version Control: https://github.com/Pylons/pyramid_mako
-
-* `pyramid_nacl_session </projects/pyramid-nacl-session/en/latest/>`_: defines
-  an encrypting, pickle-based cookie serializer, using `PyNaCl
-  <http://pynacl.readthedocs.org/en/latest/secret/>`_ to generate the symmetric
-  encryption for the cookie state.
-
-  - Maintained by: Tres Seaver
-
-  - Version Control: https://github.com/Pylons/pyramid_nacl_session
-
-* `pyramid_rpc </projects/pyramid-rpc/en/latest/>`_: RPC service add-on for
-  Pyramid, supports XML-RPC in a more extensible manner than `pyramid_xmlrpc`
-  with support for JSON-RPC and AMF.
-
-  - Maintained by: Michael Merickel, Ben Bangert
-
-  - Version Control: https://github.com/Pylons/pyramid_rpc
-
-* `pyramid_tm </projects/pyramid-tm/en/latest/>`_: Centralized transaction
-  management for Pyramid applications (without middleware).
-
-  - Maintained by: Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_tm
-
-* `pyramid_who </projects/pyramid-who/en/latest/>`_: Authentication policy for
-  pyramid using repoze.who 2.0 API.
-
-  - Maintained by: Chris McDonough, Tres Seaver
-
-  - Version Control: https://github.com/Pylons/pyramid_who
-
-* `pyramid_xmlrpc </projects/pyramid-xmlrpc/en/latest/>`_: XML-RPC add-on for
-  Pyramid
-
-  - Maintained by: Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_xmlrpc
-
-* `pyramid_zcml </projects/pyramid-zcml/en/latest/>`_: Zope Configuration
-  Markup Language configuration support for Pyramid.
-
-  - Maintained by: Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_zcml
-
-* `pyramid_zodbconn </projects/pyramid-zodbconn/en/latest/>`_: ZODB Database
-  connection management for Pyramid.
-
-  - Mantained by: Chris McDonough, Chris Rossi
-
-  - Version Control:  https://github.com/Pylons/pyramid_zodbconn
-
-Unsupported Add-Ons
-+++++++++++++++++++
-
-These are libraries which used to be officially supported by the Pylons
-Project, but have since become unsupported.
-
-* `pyramid_beaker </projects/pyramid-beaker/en/latest/>`_: Beaker session
-  backend plug-in.
-
-  - Maintained by: Ben Bangert, Chris McDonough
-
-  - Version Control: https://github.com/Pylons/pyramid_beaker
-
-  - Became unsupported October 2013 because Beaker itself is no longer
-    maintained.
-
-.. _sample_pyramid_apps:
-
-Sample Pyramid Applications
----------------------------
-
-`cluegun <https://github.com/Pylons/cluegun>`_
-  A simple pastebin application based on Rocky Burt's `ClueBin
-  <http://pypi.python.org/pypi/ClueBin/0.2.3>`_. It demonstrates form
-  processing, security, and the use of :term:`ZODB` within a :term:`Pyramid`
-  application.
-
-  - Version Control: https://github.com/Pylons/cluegun
-
-`Cornice <http://cornice.readthedocs.org/en/latest/>`_
-  Cornice provides helpers to build and document REST-ish web services with
-  Pyramid, with decent default behaviors. It takes care of following the HTTP
-  specification in an automated way where possible.
-
-  - Version Control: https://github.com/mozilla-services/cornice
-
-`KARL <http://karlproject.org>`_
-  A moderately-sized application (roughly 80K lines of Python code) built on
-  top of :term:`Pyramid`.  It is an open source web system for collaboration,
-  organizational intranets, and knowledge management. It provides facilities
-  for wikis, calendars, manuals, searching, tagging, commenting, and file
-  uploads.  See the `KARL site <http://karlproject.org>`_ for download and
-  installation details.
-
-`Kinto <http://kinto.readthedocs.org/en/latest/>`_
-  Store, Sync, Share, and Self-Host. Kinto is a lightweight JSON storage
-  service with synchronisation and sharing abilities.
-
-  - Version Control: https://github.com/Kinto/kinto
-
-`shootout <https://github.com/Pylons/shootout>`_
-  An example "idea competition" application by Carlos de la Guardia and Lukasz
-  Fidosz.  It demonstrates :term:`URL dispatch`, simple authentication,
-  integration with `SQLAlchemy <http://www.sqlalchemy.org/>`_ and
-  ``pyramid_simpleform``.
-
-  - Version Control: https://github.com/Pylons/shootout.git
-
-
-`SUMA <https://github.com/rach/suma>`_
-  Suma stands for Short URL Managment App. The role of Suma is to manage
-  external links and extract data from them. Suma is a small web service to
-  easily do the following:
-
-    - Creating short URL for external link within your application
-    - Extracting Title
-    - Capturing Screenshot from URL
-    - Blocking URLs
-    - Collecting clicks
-
-  - Version Control: https://github.com/rach/suma
-
-`virginia <https://github.com/Pylons/virginia>`_
-  A very simple dynamic file rendering application.  It is willing to render
-  structured text documents, HTML documents, and images from a filesystem
-  directory. It's also a good example of :term:`traversal`. An earlier version
-  of this application runs the `repoze.org <http://repoze.org>`_ website.
-
-  - Version Control: https://github.com/Pylons/virginia.git
-
-.. _sample_pyramid_dev_env:
-
-Sample Pyramid Development Environments
----------------------------------------
-
-"Development environments" are packages which use Pyramid as a core, but offer
-alternate services and scaffolding.  Each development environment presents a
-set of opinions and a "personality" to its users.  Although users of a
-development environment can still use all of the services offered by the
-Pyramid core, they are usually guided to a more focused set of opinions offered
-by the development environment itself.  Development environments often have
-dependencies beyond those of the Pyramid core.
-
-`Akhet <http://docs.pylonsproject.org/projects/akhet/en/latest/>`_
-  A Pyramid library and demo application with a Pylons-like feel. Its most
-  known for its former application scaffold, which helped users transition from
-  Pylons and those preferring a more Pylons-like API. The scaffold has been
-  retired but the demo plays a similar role.
-
-`Khufu Project <http://khufuproject.github.com/>`_
-  Khufu is an application scaffolding for Pyramid that provides an environment
-  to work with Jinja2 and SQLAlchemy.
-
-  - Maintained by: Rocky Burt
-  - Version Control: https://github.com/khufuproject
-
-`Kotti <http://kotti.pylonsproject.org/>`_
-  Kotti is a high-level, Pythonic web application framework. It includes an
-  extensible Content Management System called the Kotti CMS, offering all the
-  features you would expect from a modern CMS.
-
-  - Version Control: https://github.com/Kotti/Kotti
-
-`Nefertari <https://nefertari.readthedocs.org/>`_
-  Nefertari is a REST API framework for Pyramid that uses ElasticSearch for
-  reads and either MongoDB or Postgres for writes. It provides an interface to
-  ElasticSearch's `Query String DSL
-  <https://www.elastic.co/guide/en/elasticsearch/reference/1.x/query-dsl-queries.html>`_
-  for full text search.
-
-  - Version Control: https://github.com/brandicted/nefertari
-
-`Ptah <http://ptahproject.readthedocs.org/en/latest/>`_
-  Ptah is a fast, fun, open source high-level Python web development
-  environment.
-
-  - Version Control: https://github.com/ptahproject/ptah
-
-`pyramid_sacrud <http://pyramid-sacrud.readthedocs.org/en/latest/>`_
-  Pyramid CRUD interface. Provides an administration web interface for Pyramid.
-  Unlike classic CRUD, pyramid_sacrud allows overrides and flexibility to
-  customize your interface, similar to django.contrib.admin but uses a
-  different backend to provide resources. `New Architecture
-  <http://pyramid-sacrud.readthedocs.org/en/latest/pages/contribute/architecture.html>`_
-  built on the resources and mechanism traversal, allows to use it in various
-  cases.
-
-  - Version Control: https://github.com/sacrud/pyramid_sacrud
-
-`Ramses <https://ramses.readthedocs.org/>`_
-  Ramses is a library that generates a RESTful API using `RAML
-  <http://raml.org>`_. It uses Pyramid and `Nefertari
-  <https://nefertari.readthedocs.org/>`_ which provides ElasticSearch-powered
-  views.
-
-  - Version Control: https://github.com/brandicted/ramses
-
-`Ringo <http://www.ringo-framework.org>`_
-  Ringo is an extensible high-level web application framework with strength in
-  building form based management or administration software, providing ready to
-  use components often needed in web applications.
-
-  - Version Control: https://github.com/ringo-framework/ringo
-
-`Substance-D <http://substanced.net/>`_
-  An application server built upon the Pyramid web framework. It provides a
-  user interface for managing content as well as libraries and utilities which
-  make it easy to create applications.
-
-  - Version Control: https://github.com/Pylons/substanced
-
-`Ziggurat <https://github.com/sernst/Ziggurat>`_
-  A bundled application framework for data driven Pyramid project development.
-
-  - Version Control: https://github.com/sernst/Ziggurat
+Extending Pyramid
+-----------------
+
+See `Extending Pyramid
+<https://trypyramid.com/resources-extending-pyramid.html>`_ on the Pyramid
+website.


### PR DESCRIPTION
- comment pre-release of 1.8 (for future use, just uncomment)
- use fully-qualified URLs for link checking
- remove Pyramid Add-ons, replacing with link to new Extending Pyramid page on trypyramid.com